### PR TITLE
security: harden SSRF, MCP binding, and TG session

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -91,12 +91,23 @@ async def detect_platform(url: str) -> str:
 
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
-    transport = "stdio"
-    if "--transport" in sys.argv:
-        idx = sys.argv.index("--transport")
-        if idx + 1 < len(sys.argv):
-            transport = sys.argv[idx + 1]
+    parser = argparse.ArgumentParser(description="x-reader MCP Server")
+    parser.add_argument(
+        "--transport", default="stdio", choices=["stdio", "sse"],
+        help="Transport mode (default: stdio)",
+    )
+    parser.add_argument(
+        "--host", default="127.0.0.1",
+        help="Host to bind SSE server (default: 127.0.0.1). "
+        "WARNING: binding to 0.0.0.0 exposes the server to the network "
+        "without authentication — use at your own risk.",
+    )
+    parser.add_argument("--port", type=int, default=8000, help="SSE port (default: 8000)")
+    args = parser.parse_args()
 
-    mcp.run(transport=transport)
+    if args.transport == "sse":
+        mcp.run(transport="sse", host=args.host, port=args.port)
+    else:
+        mcp.run(transport="stdio")

--- a/x_reader/fetchers/telegram.py
+++ b/x_reader/fetchers/telegram.py
@@ -46,7 +46,21 @@ async def fetch_telegram(
         raise ValueError("TG_API_ID and TG_API_HASH must be set in .env")
 
     session = session_path or os.getenv("TG_SESSION_PATH", "./tg_session")
+
+    # Security: restrict session file to safe directories (prevent path traversal)
+    session_abs = os.path.abspath(session)
+    safe_dirs = [os.path.expanduser("~/.x-reader"), os.path.abspath(".")]
+    if not any(session_abs.startswith(d) for d in safe_dirs):
+        raise ValueError(
+            f"Session path must be under ~/.x-reader/ or current directory, got: {session}"
+        )
+
     cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+
+    # Lock down session file permissions (contains auth tokens)
+    session_file = session_abs + ".session"
+    if os.path.exists(session_file):
+        os.chmod(session_file, 0o600)
 
     messages = []
     async with TelegramClient(session, int(api_id), api_hash) as client:

--- a/x_reader/reader.py
+++ b/x_reader/reader.py
@@ -16,6 +16,7 @@ from x_reader.schema import (
     from_xiaohongshu, from_youtube, from_rss, from_telegram,
 )
 from x_reader.fetchers.jina import fetch_via_jina
+from x_reader.utils.url_validator import validate_url
 
 
 class UniversalReader:
@@ -60,6 +61,9 @@ class UniversalReader:
         # Ensure URL has scheme
         if not url.startswith(("http://", "https://")):
             url = f"https://{url}"
+
+        # SSRF protection: block private IPs, metadata endpoints, DNS rebinding
+        validate_url(url)
 
         platform = self._detect_platform(url)
         logger.info(f"[{platform}] {url[:60]}...")

--- a/x_reader/utils/url_validator.py
+++ b/x_reader/utils/url_validator.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+URL validation — blocks SSRF attempts (private IPs, metadata endpoints, DNS rebinding).
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# Private/reserved networks that should never be accessed via user-supplied URLs
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local + AWS metadata
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fd00::/8"),
+]
+
+
+def validate_url(url: str) -> str:
+    """
+    Validate a URL is safe to fetch (not targeting internal resources).
+
+    Checks:
+    1. Scheme must be http or https
+    2. Hostname must exist
+    3. Resolved IP must not be private/loopback/link-local
+
+    Returns the validated URL. Raises ValueError if blocked.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Blocked: unsupported scheme '{parsed.scheme}'")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Blocked: no hostname in URL")
+
+    # Resolve hostname to IP — catches DNS rebinding (evil.com → 127.0.0.1)
+    try:
+        resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror:
+        raise ValueError(f"Blocked: cannot resolve hostname '{hostname}'")
+
+    for family, _, _, _, sockaddr in resolved:
+        ip = ipaddress.ip_address(sockaddr[0])
+        for network in _BLOCKED_NETWORKS:
+            if ip in network:
+                raise ValueError(
+                    f"Blocked: '{hostname}' resolves to private address {ip}"
+                )
+
+    return url


### PR DESCRIPTION
## Summary
- **SSRF protection**: new `url_validator.py` blocks private IPs, AWS metadata endpoint, and DNS rebinding attacks
- **MCP server**: SSE transport now binds `127.0.0.1` by default; explicit `--host 0.0.0.0` required to expose
- **Telegram session**: file permissions locked to `0o600`, path traversal check added

## Test plan
- [x] Public URLs (google.com, example.com) pass through normally
- [x] Private IPs (127.0.0.1, 10.x, 192.168.x) blocked with clear error
- [x] AWS metadata (169.254.169.254) blocked
- [x] `mcp_server.py --help` shows new `--host` flag
- [x] Integration test: `UniversalReader.read()` blocks SSRF at entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)