### PR TITLE
fix(twitter): use system Chrome channel for login and Playwright fallback

### DIFF
--- a/x_reader/fetchers/twitter.py
+++ b/x_reader/fetchers/twitter.py
@@ -84,7 +84,11 @@ async def _fetch_via_playwright(url: str) -> Dict[str, Any]:
         logger.info(f"Using saved X session: {session_path}")
 
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
+        browser = await p.chromium.launch(
+            headless=True,
+            channel="chrome",
+            args=["--disable-blink-features=AutomationControlled"],
+        )
 
         context_kwargs = {}
         if has_session:

--- a/x_reader/login.py
+++ b/x_reader/login.py
@@ -65,7 +65,12 @@ def login(platform: str) -> None:
     print("   When done, close the browser or press Ctrl+C.\n")
 
     with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False)
+        # Prefer real Chrome channel over bundled Chromium to reduce login friction.
+        browser = p.chromium.launch(
+            headless=False,
+            channel="chrome",
+            args=["--disable-blink-features=AutomationControlled"],
+        )
         context = browser.new_context(
             user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                        "AppleWebKit/537.36 (KHTML, like Gecko) "


### PR DESCRIPTION
Use system Chrome channel for login and Playwright fallback to reduce X login friction and improve compatibility.