### PR TITLE
fix(twitter): fallback when oEmbed returns only t.co stub

### DIFF
--- a/x_reader/fetchers/twitter.py
+++ b/x_reader/fetchers/twitter.py
@@ -155,9 +155,16 @@ async def fetch_twitter(url: str) -> Dict[str, Any]:
         try:
             logger.info(f"[Twitter] Tier 1 — oEmbed: {url}")
             data = _fetch_via_oembed(url)
-            if data.get("text") and len(data["text"].strip()) > 20:
+            text = (data.get("text") or "").strip()
+            # Some oEmbed responses are only a t.co stub + author/date.
+            thin_oembed = (
+                len(text) <= 20
+                or text.lower().startswith("https://t.co/")
+                or ("&mdash;" in text and text.count("https://t.co/") >= 1)
+            )
+            if not thin_oembed:
                 return {
-                    "text": data["text"],
+                    "text": text,
                     "author": author or data.get("author", ""),
                     "url": url,
                     "title": data.get("title", ""),


### PR DESCRIPTION
## What
Improve Twitter/X Tier-1 handling by detecting thin oEmbed payloads (t.co-only stubs) and continuing to Tier-2/Tier-3 fetchers.

## Why
Some posts return oEmbed content that is technically non-empty but not useful (just shortened URL + author/date). Previously this was treated as success and stopped fallback.

## Changes
- In `fetch_twitter`, classify oEmbed as thin when:
  - text is too short, or
  - starts with `https://t.co/`, or
  - contains `&mdash;` and t.co stub pattern
- Only return Tier-1 result when content is not thin.

## Result
`x-reader` now correctly falls through to richer extraction paths and returns actual article/tweet content more reliably.
