### PR TITLE
fix: fallback to Chromium when Chrome unavailable (ARM64)

### DIFF
--- a/x_reader/login.py
+++ b/x_reader/login.py
@@ -86,12 +86,15 @@ def _login_visible(login_url: str, session_path: Path, platform: str) -> None:
     print("   When done, close the browser or press Ctrl+C.\n")
 
     with sync_playwright() as p:
-        # Prefer real Chrome channel over bundled Chromium to reduce login friction.
-        browser = p.chromium.launch(
+        # Prefer real Chrome, fall back to bundled Chromium (e.g. Linux ARM64).
+        launch_args = dict(
             headless=False,
-            channel="chrome",
             args=["--disable-blink-features=AutomationControlled"],
         )
+        try:
+            browser = p.chromium.launch(channel="chrome", **launch_args)
+        except Exception:
+            browser = p.chromium.launch(**launch_args)
         context = browser.new_context(
             user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                        "AppleWebKit/537.36 (KHTML, like Gecko) "


### PR DESCRIPTION
## Summary
- Chrome channel is not available on Linux ARM64, causing `login` to crash
- Try `channel="chrome"` first, catch exception and fall back to bundled Chromium

Closes #12