### PR TITLE
fix(wechat): fall back to Playwright when Jina returns CAPTCHA stub

### DIFF
--- a/x_reader/fetchers/wechat.py
+++ b/x_reader/fetchers/wechat.py
@@ -38,15 +38,28 @@ async def fetch_wechat(url: str) -> Dict[str, Any]:
         from x_reader.fetchers.jina import fetch_via_jina
 
         data = fetch_via_jina(url)
-        if data.get("content"):
+        content = data.get("content", "") or ""
+        title = data.get("title", "") or ""
+        captcha_markers = (
+            "requiring CAPTCHA",
+            "not yet fully loaded",
+            "Weixin Official Accounts Platform",
+            "请输入验证码",
+            "环境异常",
+        )
+        looks_blocked = any(m in content or m in title for m in captcha_markers)
+        if content and not looks_blocked:
             return {
-                "title": data["title"],
-                "content": _proxy_wechat_images(data["content"]),
+                "title": title,
+                "content": _proxy_wechat_images(content),
                 "author": data.get("author", ""),
                 "url": url,
                 "platform": "wechat",
             }
-        logger.warning("[WeChat] Jina returned empty content, falling back to browser")
+        if looks_blocked:
+            logger.warning("[WeChat] Jina hit CAPTCHA/anti-scrape page, falling back to browser")
+        else:
+            logger.warning("[WeChat] Jina returned empty content, falling back to browser")
     except Exception as e:
         logger.warning(f"[WeChat] Jina failed ({e}), falling back to browser")
 


### PR DESCRIPTION
## Summary

The WeChat Tier-1 → Tier-2 fallback in `x_reader/fetchers/wechat.py` only fired when Jina returned **empty** content. But blocked `mp.weixin.qq.com` URLs make Jina return a **non-empty** stub:

> Title: `Weixin Official Accounts Platform`
> Content: `Warning: This page maybe not yet fully loaded, consider explicitly specify a timeout. Warning: This page maybe requiring CAPTCHA, please ...`

`data.get("content")` is truthy → the early return fires → Tier-2 Playwright is never reached → the inbox gets a junk record while the real article is silently dropped.

## Fix

Add a small marker list (`requiring CAPTCHA`, `not yet fully loaded`, `Weixin Official Accounts Platform`, `请输入验证码`, `环境异常`). If any marker shows up in title or content, treat Tier 1 as a miss and fall through to the browser tier.

## Repro

```bash
x-reader https://mp.weixin.qq.com/s/qExXEPAaMGiTJRXybJn00w
```

**Before:**
```
✅ [wechat] Title: Weixin Official Accounts Platform
```

**After:**
```
[WeChat] Jina hit CAPTCHA/anti-scrape page, falling back to browser
[WeChat] Tier 2 — Playwright headless: ...
✅ [wechat] 10个宝藏Skills，从各领域精选，每个都是能直接上手的好东西
```

## Test plan

- [x] Re-fetch a CAPTCHA-blocked WeChat URL → falls back to Playwright, real title saved
- [x] Re-fetch a normal (Jina-friendly) WeChat URL → still served from Tier 1 (no perf regression)
- [ ] Maintainer can verify with any blocked `mp.weixin.qq.com` URL

## Notes

Markers are conservative — I only listed strings actually observed from Jina + a couple of common Chinese anti-bot phrases. Easy to extend if you hit new variants.