### PR TITLE
fix(wechat): detect Jina CAPTCHA stub and fall back to Playwright

### DIFF
--- a/x_reader/fetchers/wechat.py
+++ b/x_reader/fetchers/wechat.py
@@ -38,15 +38,17 @@ async def fetch_wechat(url: str) -> Dict[str, Any]:
         from x_reader.fetchers.jina import fetch_via_jina
 
         data = fetch_via_jina(url)
-        if data.get("content"):
+        content = data.get("content", "")
+        is_captcha = "[去验证]" in content or data.get("title") == "Weixin Official Accounts Platform"
+        if content and not is_captcha:
             return {
                 "title": data["title"],
-                "content": _proxy_wechat_images(data["content"]),
+                "content": _proxy_wechat_images(content),
                 "author": data.get("author", ""),
                 "url": url,
                 "platform": "wechat",
             }
-        logger.warning("[WeChat] Jina returned empty content, falling back to browser")
+        logger.warning("[WeChat] Jina returned CAPTCHA/anti-scrape stub, falling back to browser")
     except Exception as e:
         logger.warning(f"[WeChat] Jina failed ({e}), falling back to browser")
 


### PR DESCRIPTION
## Summary

`fetchers/wechat.py` Tier 1 considered Jina's response a successful fetch as long as `content` was non-empty. When WeChat blocks the request, Jina returns a non-empty "环境异常 / 完成验证后即可继续访问" interstitial, so:

- Tier 2 Playwright fallback was **never triggered** for blocked pages
- Callers received the captcha placeholder as the article body
- Repro: fetch any public article from an IP that triggers WeChat's verification gate

## Fix

Detect the interstitial via two sentinels Jina emits on the captcha page and demote it to a fall-through:

- `[去验证]` link in the markdown body
- `"Weixin Official Accounts Platform"` as the page title (Jina's default when extraction yields nothing)

Either match → log warning, fall back to Tier 2 Playwright (which already works correctly).

```diff
- if data.get("content"):
+ content = data.get("content", "")
+ is_captcha = "[去验证]" in content or data.get("title") == "Weixin Official Accounts Platform"
+ if content and not is_captcha:
```

## Test

Before — captcha stub returned as article body:

```
Tier 1 — Jina: https://mp.weixin.qq.com/s/GkeO0_BuNnI6T-yaVL67Ww
Saved to inbox: Title: Weixin Official Accounts Platform
```

After — captcha detected, Playwright takes over:

```
Tier 1 — Jina: https://mp.weixin.qq.com/s/GkeO0_BuNnI6T-yaVL67Ww
WARNING [WeChat] Jina returned CAPTCHA/anti-scrape stub, falling back to browser
Tier 2 — Playwright headless
Browser fetch OK: 盘点 10 个刚刚开源，但 Star 攀升很快的 GitHub 项目。
```

## Notes

- Surgical change: 5 insertions / 3 deletions in `wechat.py`, no other files touched
- The two sentinels are specific to Jina's anti-scrape stub — won't false-positive on real articles