### PR TITLE
fix(xhs): detect Jina login-wall stub and fall back to Playwright

### DIFF
--- a/x_reader/fetchers/xhs.py
+++ b/x_reader/fetchers/xhs.py
@@ -30,15 +30,21 @@ async def fetch_xhs(url: str) -> Dict[str, Any]:
     try:
         logger.info(f"[XHS] Tier 1 — Jina: {url}")
         data = fetch_via_jina(url)
-        if data.get("content"):
+        content = data.get("content", "")
+        title = data.get("title", "")
+        is_login_wall = (
+            "小红书 - 你的生活兴趣社区" in title
+            or "登录后推荐更懂你的笔记" in content
+        )
+        if content and not is_login_wall:
             return {
-                "title": data["title"],
-                "content": data["content"],
+                "title": title,
+                "content": content,
                 "author": data.get("author", ""),
                 "url": url,
                 "platform": "xhs",
             }
-        logger.warning("[XHS] Jina returned empty content, falling back to browser")
+        logger.warning("[XHS] Jina returned login-wall stub, falling back to browser")
     except Exception as e:
         logger.warning(f"[XHS] Jina failed ({e}), falling back to browser")
 


### PR DESCRIPTION
## Summary

`fetchers/xhs.py` Tier 1 considered Jina's response a successful fetch as long as `content` was non-empty. When Xiaohongshu blocks the request, Jina returns a non-empty **login-wall stub** (default site title + "登录后推荐更懂你的笔记" body), so:

- Tier 2 Playwright (with saved session) was **never triggered** for blocked pages
- Callers received the login-wall HTML as the note body
- Repro: fetch any XHS `explore/...` URL — even with a valid saved session, the stub from Tier 1 short-circuits the browser path

This is the **same shape** as #18 ([fix(wechat): detect Jina CAPTCHA stub](https://github.com/runesleo/x-reader/pull/18)); both Tier-1-blocking platforms share the bug pattern.

## Fix

Detect the login-wall via two sentinels Jina emits when it can't extract real content:

- `title` contains `"小红书 - 你的生活兴趣社区"` (XHS default site title — never appears for a real note page)
- `content` contains `"登录后推荐更懂你的笔记"` (login wall body)

Either match → log warning and fall through to Tier 2 (which already works correctly when a session is present).

```diff
- if data.get("content"):
+ content = data.get("content", "")
+ title = data.get("title", "")
+ is_login_wall = (
+     "小红书 - 你的生活兴趣社区" in title
+     or "登录后推荐更懂你的笔记" in content
+ )
+ if content and not is_login_wall:
```

## Test

Before — login-wall stub returned as note body (title was "Title: 小红书 - 你的生活兴趣社区"):

```
[XHS] Tier 1 — Jina: ...
Saved to inbox: Title: 小红书 - 你的生活兴趣社区
```

After — stub detected, Playwright with session takes over and returns the actual note:

```
[XHS] Tier 1 — Jina: ...
WARNING [XHS] Jina returned login-wall stub, falling back to browser
[XHS] Tier 2 — Playwright with session: ...
Browser fetch OK: 你写的 agent 代码，有多少现在可以删掉？
```

Tested on a real `explore/...` URL with `xsec_token`, with a valid session at `~/.x-reader/sessions/xhs.json`.

## Notes

- Surgical change: 10 insertions / 4 deletions in `xhs.py`, no other files touched
- Sentinels are specific to Jina's anti-scrape stub — real notes never have either string at title/body level
- Sibling PR for the WeChat fetcher: #18