### PR TITLE
Improve X/Twitter reader fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Universal content reader — fetch, transcribe, and digest content from any plat
 
 Give it a URL (article, video, podcast, tweet), get back structured content. Works as CLI, Python library, MCP server, or Claude Code skills.
 
-**简体中文：** [README.zh-CN.md](./README.zh-CN.md)
+**简体中文：** [README.zh.md](./README.zh.md) / [README.zh-CN.md](./README.zh-CN.md)
 
 ## What It Does
 
@@ -29,7 +29,7 @@ x-reader is composable. Use the layers you need:
 | Layer | What | Format | Install |
 |-------|------|--------|---------|
 | **Python CLI/Library** | Basic content fetching + unified schema | See [Install](#install) | Required |
-| **Claude Code Skills** | Video transcription + AI analysis | Copy `skills/` to `~/.claude/skills/` | Optional |
+| **Claude Code Skills** | Video transcription + AI analysis | Copy `skills/` to your Claude Code skills directory | Optional |
 | **MCP Server** | Expose reading as MCP tools | `python mcp_server.py` | Optional |
 
 ### Layer 1: Python CLI
@@ -65,8 +65,10 @@ skills/
 
 Install:
 ```bash
-cp -r skills/video ~/.claude/skills/video
-cp -r skills/analyzer ~/.claude/skills/analyzer
+export CLAUDE_SKILLS_DIR="/path/to/claude-code-skills"
+mkdir -p "$CLAUDE_SKILLS_DIR"
+cp -r skills/video "$CLAUDE_SKILLS_DIR/video"
+cp -r skills/analyzer "$CLAUDE_SKILLS_DIR/analyzer"
 ```
 
 Then in Claude Code, just send a YouTube/Bilibili/podcast link — the video skill auto-triggers and produces a full transcript + summary.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Claude Code config (`~/.claude/claude_desktop_config.json`):
 |----------|-----------|----------------------|
 | YouTube | ✅ Jina | ✅ yt-dlp subtitles → Groq Whisper fallback |
 | Bilibili (B站) | ✅ API | ✅ via Claude Code skill |
-| X / Twitter | ✅ Jina → Playwright | — |
+| X / Twitter | ✅ oEmbed → FxTwitter → Article/Jina → Playwright | — |
 | WeChat (微信公众号) | ✅ Jina → Playwright | — |
 | Xiaohongshu (小红书) | ✅ Jina → Playwright* | — |
 | Telegram | ✅ Telethon | — |
@@ -117,7 +117,33 @@ Claude Code config (`~/.claude/claude_desktop_config.json`):
 
 > \*XHS requires a one-time login: `x-reader login xhs` (saves session for Playwright fallback)
 >
+> X Articles and login-required X pages can use a saved local browser session: `x-reader login twitter`
+>
 > YouTube Whisper transcription requires `GROQ_API_KEY` — get a free key from [Groq](https://console.groq.com/keys)
+
+### X / Twitter Reading Path
+
+`x-reader` uses a lightweight public-first chain for X:
+
+1. X oEmbed for fast public tweet text.
+2. FxTwitter for structured public tweet fallback.
+3. Jina Reader for public Articles and long-form pages.
+4. Generic Jina Reader for profiles and non-status X pages.
+5. Playwright with saved session for login-required content.
+
+For Articles or gated pages, run:
+
+```bash
+x-reader login twitter
+x-reader "https://x.com/user/status/123"
+```
+
+By default, local X cookies stay local. If you explicitly want to let Jina use
+your saved X session for gated Articles, set:
+
+```bash
+export X_READER_ALLOW_EXTERNAL_SESSION_COOKIES=1
+```
 
 ## Install
 
@@ -209,7 +235,7 @@ x-reader/
 │   │   ├── youtube.py     # yt-dlp subtitle extraction
 │   │   ├── rss.py         # feedparser
 │   │   ├── telegram.py    # Telethon
-│   │   ├── twitter.py     # Jina-based
+│   │   ├── twitter.py     # oEmbed → FxTwitter → Article/Jina → Playwright
 │   │   ├── wechat.py      # Jina → Playwright fallback
 │   │   └── xhs.py         # Jina → Playwright + session fallback
 │   └── utils/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,13 +62,36 @@ python mcp_server.py
 |------|------|-------------|
 | YouTube | ✅ | ✅ 字幕 / Groq Whisper |
 | Bilibili | ✅ API | ✅（经 Skill） |
-| X / Twitter | ✅ | — |
+| X / Twitter | ✅ oEmbed → FxTwitter → Article/Jina → Playwright | — |
 | 微信公众号 | ✅ | — |
 | 小红书 | ✅（需登录） | — |
 | Telegram | ✅ Telethon | — |
 | RSS | ✅ | — |
 
+> X Article 或需登录的 X 页面，可先运行 `x-reader login twitter` 保存本地浏览器会话。
+>
 > YouTube Whisper 需 `GROQ_API_KEY`（[Groq](https://console.groq.com/keys) 免费申请）。
+
+### X / Twitter 读取链路
+
+`x-reader` 现在按轻量公开链路优先读取 X：
+
+1. oEmbed：快速读取公开推文。
+2. FxTwitter：结构化公开推文 fallback。
+3. Jina Reader：读取公开 Article 和长内容页面。
+4. 通用 Jina Reader：读取 profile 和非 status 页面。
+5. Playwright + 已保存会话：处理需要登录的内容。
+
+```bash
+x-reader login twitter
+x-reader "https://x.com/user/status/123"
+```
+
+默认情况下，本地 X cookie 只留在本机。只有你明确信任 Jina 并设置下面这个环境变量时，x-reader 才会把已保存的 X session 交给 Jina 读取 gated Article：
+
+```bash
+export X_READER_ALLOW_EXTERNAL_SESSION_COOKIES=1
+```
 
 ## 安装
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,5 @@
+# x-reader
+
+[English](./README.md)
+
+简体中文文档已迁移到 [README.zh-CN.md](./README.zh-CN.md)。

--- a/docs/share-cards.html
+++ b/docs/share-cards.html
@@ -247,7 +247,7 @@
     <div class="arch-layer layer-2">
       <div class="layer-label">Layer 2 · AI 增强层</div>
       <div class="layer-title">Claude Code Skills</div>
-      <div class="layer-desc">复制 skills/ 到 ~/.claude/skills/ 即可。发视频/播客链接 → 自动 Whisper 转写全文 → 结构化摘要 + 行动清单</div>
+      <div class="layer-desc">复制 skills/ 到你的 Claude Code skills 目录即可。发视频/播客链接 → 自动 Whisper 转写全文 → 结构化摘要 + 行动清单</div>
     </div>
 
     <div class="arrow-down">↓ 可选扩展</div>

--- a/examples/cookbook/01_validate_url_batch.py
+++ b/examples/cookbook/01_validate_url_batch.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Scenario: Batch-validate user-supplied URLs before any network I/O (SSRF guard).
+# Learning goal: compose `validate_url` in a loop; fail-fast vs collect-errors.
+# Prereqs: `pip install -e .` from repo root; no fetch occurs here.
+# Edge case: first blocked URL raises — wrap per-URL try for partial reports.
+# Run: python examples/cookbook/01_validate_url_batch.py
+
+from __future__ import annotations
+
+from x_reader.utils.url_validator import validate_url
+
+URLS = [
+    "https://example.com/article",
+    "https://youtube.com/watch?v=dQw4w9WgXcQ",
+]
+
+
+def main() -> None:
+    clean = []
+    for u in URLS:
+        clean.append(validate_url(u))
+    print("ok", len(clean))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/02_platform_routing_preview.py
+++ b/examples/cookbook/02_platform_routing_preview.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Scenario: Preview platform routing for a list of URLs (no fetch).
+# Learning goal: `UniversalReader._detect_platform` drives fetcher choice.
+# Prereqs: install package editable; uses a private method for introspection.
+# Edge case: scheme-less URLs differ from CLI auto-prefix behavior.
+# Run: python examples/cookbook/02_platform_routing_preview.py
+
+from __future__ import annotations
+
+from x_reader.reader import UniversalReader
+
+SAMPLES = [
+    "https://x.com/user/status/1",
+    "https://www.youtube.com/watch?v=1",
+    "https://example.com/feed.xml",
+]
+
+
+def main() -> None:
+    r = UniversalReader()
+    for u in SAMPLES:
+        print(u, "->", r._detect_platform(u))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/03_unified_content_roundtrip.py
+++ b/examples/cookbook/03_unified_content_roundtrip.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Scenario: Serialize `UnifiedContent` to dict and back (tool composition).
+# Learning goal: stable schema for passing between CLI, MCP, and storage.
+# Prereqs: `x_reader.schema` imports only.
+# Edge case: unknown keys in dict are stripped by `from_dict`.
+# Run: python examples/cookbook/03_unified_content_roundtrip.py
+
+from __future__ import annotations
+
+import json
+
+from x_reader.schema import MediaType, Priority, SourceType, UnifiedContent
+
+
+def main() -> None:
+    u = UnifiedContent(
+        source_type=SourceType.MANUAL,
+        source_name="demo",
+        title="t",
+        content="body",
+        url="https://example.com",
+        media_type=MediaType.TEXT,
+        priority=Priority.NORMAL,
+    )
+    raw = json.dumps(u.to_dict(), ensure_ascii=False)
+    back = UnifiedContent.from_dict(json.loads(raw))
+    assert back.title == u.title
+    print("roundtrip ok", back.id)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/04_from_telegram_stub.py
+++ b/examples/cookbook/04_from_telegram_stub.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Scenario: Build `UnifiedContent` from a stub Telegram message dict.
+# Learning goal: `from_telegram` normalizes channel metadata into schema.
+# Prereqs: schema helpers only; no Telethon session.
+# Edge case: missing `text` yields empty title; still valid object.
+# Run: python examples/cookbook/04_from_telegram_stub.py
+
+from __future__ import annotations
+
+from x_reader.schema import from_telegram
+
+
+def main() -> None:
+    msg = {"text": "hello world", "url": "https://t.me/demo/123", "views": 42}
+    u = from_telegram(msg, channel_name="Demo", channel_username="demo")
+    print(u.source_type.value, u.extra.get("views"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/05_async_batch_gather_errors.py
+++ b/examples/cookbook/05_async_batch_gather_errors.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Scenario: Mirror `read_batch` semantics with stub coroutines (error handling).
+# Learning goal: `asyncio.gather(..., return_exceptions=True)` preserves partials.
+# Prereqs: Python 3.10+ asyncio.
+# Edge case: exceptions stay in results list — filter before downstream merge.
+# Run: python examples/cookbook/05_async_batch_gather_errors.py
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def maybe_fail(i: int) -> int:
+    if i == 1:
+        raise ValueError("boom")
+    return i
+
+
+async def main() -> None:
+    tasks = [maybe_fail(i) for i in range(3)]
+    out = await asyncio.gather(*tasks, return_exceptions=True)
+    ok = [x for x in out if not isinstance(x, Exception)]
+    bad = [x for x in out if isinstance(x, Exception)]
+    print("ok", ok, "errors", len(bad))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/cookbook/06_reader_without_inbox.py
+++ b/examples/cookbook/06_reader_without_inbox.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Scenario: Construct `UniversalReader` without disk inbox (read-only session).
+# Learning goal: inbox is optional; skips persistence side effects in `read`.
+# Prereqs: package installed; still performs network if you call `read`.
+# Edge case: passing `inbox=None` disables `add/save` path inside `read`.
+# Run: python examples/cookbook/06_reader_without_inbox.py  (no network here)
+
+from __future__ import annotations
+
+from x_reader.reader import UniversalReader
+
+
+def main() -> None:
+    r = UniversalReader(inbox=None)
+    assert r.inbox is None
+    print("reader ready without inbox")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/07_validate_url_error_handling.py
+++ b/examples/cookbook/07_validate_url_error_handling.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Scenario: Catch `ValueError` from `validate_url` for bad schemes / SSRF patterns.
+# Learning goal: surface user-facing errors before spawning fetchers.
+# Prereqs: validator module only.
+# Edge case: operator confuses `file://` — blocked early.
+# Run: python examples/cookbook/07_validate_url_error_handling.py
+
+from __future__ import annotations
+
+from x_reader.utils.url_validator import validate_url
+
+
+def safe_validate(u: str) -> str | None:
+    try:
+        return validate_url(u)
+    except ValueError as e:
+        print("blocked:", e)
+        return None
+
+
+def main() -> None:
+    assert safe_validate("http://127.0.0.1/secret") is None
+    print("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/08_from_rss_minimal.py
+++ b/examples/cookbook/08_from_rss_minimal.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Scenario: Convert a minimal RSS article dict to `UnifiedContent`.
+# Learning goal: `from_rss` maps `link`/`url` fields defensively.
+# Prereqs: schema only.
+# Edge case: missing summary becomes empty string.
+# Run: python examples/cookbook/08_from_rss_minimal.py
+
+from __future__ import annotations
+
+from x_reader.schema import from_rss
+
+
+def main() -> None:
+    article = {
+        "source": "Example Feed",
+        "title": "Hello",
+        "summary": "World",
+        "link": "https://example.com/a",
+    }
+    u = from_rss(article)
+    print(u.url, u.title)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/09_compose_mcp_tool_payloads.py
+++ b/examples/cookbook/09_compose_mcp_tool_payloads.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Scenario: Build JSON payloads matching MCP tool shapes (`read_batch`).
+# Learning goal: glue layer between agent and `mcp_server` contracts.
+# Prereqs: stdlib json only; does not start MCP.
+# Edge case: empty list should be rejected by server — validate len ≥ 1.
+# Run: python examples/cookbook/09_compose_mcp_tool_payloads.py
+
+from __future__ import annotations
+
+import json
+
+from x_reader.utils.url_validator import validate_url
+
+
+def build_read_batch(urls: list[str]) -> str:
+    cleaned = [validate_url(u) for u in urls]
+    return json.dumps({"urls": cleaned}, ensure_ascii=False)
+
+
+def main() -> None:
+    payload = build_read_batch(
+        ["https://example.com/a", "https://example.com/b"],
+    )
+    print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/10_zip_url_outcomes.py
+++ b/examples/cookbook/10_zip_url_outcomes.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Scenario: Zip URLs to per-URL outcomes after a batch gather (like `read_batch`).
+# Learning goal: keep alignment between request list and mixed results.
+# Prereqs: stdlib only; mirrors `zip(urls, results)` in `reader.py`.
+# Edge case: shorter results list indicates a bug — assert equal lengths.
+# Run: python examples/cookbook/10_zip_url_outcomes.py
+
+from __future__ import annotations
+
+from typing import Any
+
+URLS = ["https://example.com/a", "https://example.com/b"]
+RESULTS: list[Any] = ["ok", ValueError("x")]
+
+
+def main() -> None:
+    for url, res in zip(URLS, RESULTS):
+        if isinstance(res, Exception):
+            print(url, "ERR", type(res).__name__)
+        else:
+            print(url, res)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_twitter_fetcher.py
+++ b/tests/test_twitter_fetcher.py
@@ -1,0 +1,176 @@
+import unittest
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import types
+
+
+class _DummyLogger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warning(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+
+sys.modules.setdefault("loguru", types.SimpleNamespace(logger=_DummyLogger()))
+
+from x_reader.fetchers import twitter
+from x_reader.schema import from_twitter
+
+
+class TwitterFetcherHelpersTest(unittest.TestCase):
+    def test_normalize_x_url(self):
+        self.assertEqual(
+            twitter._normalize_x_url(
+                "https://twitter.com/runesleo/status/123?s=20&t=tracking"
+            ),
+            "https://x.com/runesleo/status/123",
+        )
+        self.assertEqual(
+            twitter._normalize_x_url(
+                "https://mobile.twitter.com/runesleo/status/123#fragment"
+            ),
+            "https://x.com/runesleo/status/123",
+        )
+        self.assertEqual(
+            twitter._normalize_x_url("x.com/runesleo/status/123?s=20"),
+            "https://x.com/runesleo/status/123",
+        )
+
+    def test_extract_status_id_common_shapes(self):
+        self.assertEqual(
+            twitter._extract_status_id("https://x.com/runesleo/status/123"), "123"
+        )
+        self.assertEqual(
+            twitter._extract_status_id("https://x.com/i/web/status/456"), "456"
+        )
+        self.assertEqual(
+            twitter._extract_status_id("https://x.com/i/article/789"), "789"
+        )
+        self.assertEqual(
+            twitter._extract_status_id("https://x.com/runesleo/article/101"), "101"
+        )
+
+    def test_strip_tweet_html_removes_embed_chrome(self):
+        html = (
+            '<blockquote><p lang="zh">第一行<br>第二行 '
+            '<a href="https://t.co/abc">pic.twitter.com/abc</a></p>'
+            '&mdash; Leo (@runesleo) <a href="https://x.com/runesleo/status/1">'
+            "May 31, 2026</a></blockquote>"
+        )
+        self.assertEqual(
+            twitter._strip_tweet_html(html),
+            "第一行\n第二行 pic.twitter.com/abc",
+        )
+
+    def test_detect_thin_oembed_text(self):
+        self.assertTrue(twitter._is_thin_oembed_text("https://t.co/abc123"))
+        self.assertTrue(twitter._is_thin_oembed_text("短句"))
+        self.assertTrue(twitter._is_thin_oembed_text("这是一段被截断的内容…"))
+        self.assertFalse(
+            twitter._is_thin_oembed_text(
+                "这是一个完整的公开推文内容，长度足够，也没有只剩短链。"
+            )
+        )
+
+    def test_from_twitter_keeps_fetch_metadata(self):
+        content = from_twitter(
+            {
+                "text": "hello",
+                "author": "@runesleo",
+                "url": "https://x.com/runesleo/status/1",
+                "fetch_method": "oembed",
+                "author_url": "https://x.com/runesleo",
+            }
+        )
+        self.assertEqual(content.extra["fetch_method"], "oembed")
+        self.assertEqual(content.extra["author_url"], "https://x.com/runesleo")
+
+    def test_session_cookies_require_explicit_external_opt_in(self):
+        from x_reader.fetchers import browser
+
+        original_get_session_path = browser.get_session_path
+        original_env = os.environ.get("X_READER_ALLOW_EXTERNAL_SESSION_COOKIES")
+        try:
+            with tempfile.NamedTemporaryFile("w", delete=False) as handle:
+                json.dump(
+                    {
+                        "cookies": [
+                            {
+                                "name": "auth_token",
+                                "value": "test-cookie-value",
+                                "domain": ".x.com",
+                            }
+                        ]
+                    },
+                    handle,
+                )
+                session_path = handle.name
+
+            browser.get_session_path = lambda _platform: session_path
+            os.environ.pop("X_READER_ALLOW_EXTERNAL_SESSION_COOKIES", None)
+            self.assertIsNone(twitter._session_cookie_header())
+
+            os.environ["X_READER_ALLOW_EXTERNAL_SESSION_COOKIES"] = "1"
+            self.assertEqual(
+                twitter._session_cookie_header(), "auth_token=test-cookie-value"
+            )
+        finally:
+            browser.get_session_path = original_get_session_path
+            if original_env is None:
+                os.environ.pop("X_READER_ALLOW_EXTERNAL_SESSION_COOKIES", None)
+            else:
+                os.environ["X_READER_ALLOW_EXTERNAL_SESSION_COOKIES"] = original_env
+            if "session_path" in locals():
+                os.unlink(session_path)
+
+    def test_fetch_twitter_uses_oembed_when_content_is_complete(self):
+        original = twitter._fetch_via_oembed
+        try:
+            twitter._fetch_via_oembed = lambda _url: {
+                "text": "这是一个完整的公开推文内容，长度足够，可以直接使用。",
+                "author": "Leo",
+                "title": "这是一个完整的公开推文内容",
+            }
+            data = asyncio.run(
+                twitter.fetch_twitter("https://x.com/runesleo/status/123?s=20")
+            )
+        finally:
+            twitter._fetch_via_oembed = original
+
+        self.assertEqual(data["fetch_method"], "oembed")
+        self.assertEqual(data["url"], "https://x.com/runesleo/status/123")
+
+    def test_fetch_twitter_falls_back_after_thin_oembed(self):
+        original_oembed = twitter._fetch_via_oembed
+        original_fx = twitter._fetch_via_fxtwitter
+        try:
+            twitter._fetch_via_oembed = lambda _url: {
+                "text": "https://t.co/abc123",
+                "author": "Leo",
+                "title": "",
+            }
+            twitter._fetch_via_fxtwitter = lambda _url: {
+                "text": "FxTwitter 返回的完整正文",
+                "author": "@runesleo",
+                "title": "FxTwitter 返回的完整正文",
+            }
+            data = asyncio.run(
+                twitter.fetch_twitter("https://x.com/runesleo/status/123")
+            )
+        finally:
+            twitter._fetch_via_oembed = original_oembed
+            twitter._fetch_via_fxtwitter = original_fx
+
+        self.assertEqual(data["fetch_method"], "fxtwitter")
+        self.assertEqual(data["text"], "FxTwitter 返回的完整正文")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/x_reader/fetchers/twitter.py
+++ b/x_reader/fetchers/twitter.py
@@ -1,37 +1,143 @@
 # -*- coding: utf-8 -*-
 """
-X/Twitter fetcher — four-tier fallback:
+X/Twitter fetcher — production-style fallback:
 
-1. FxTwitter API (full text, structured JSON, no auth needed)
-2. X oEmbed API (fast, but truncates long tweets)
-3. Jina Reader (handles non-tweet X pages like profiles)
-4. Playwright + saved session (handles login-required content)
+1. X oEmbed probe (fast, no auth, good for public tweets)
+2. FxTwitter API (structured fallback for public tweets)
+3. X Article via Jina (public content; external cookies require explicit opt-in)
+4. Jina Reader (profiles and non-tweet X pages)
+5. Playwright + saved session (login-required content)
 
 Install browser tier: pip install "x-reader[browser]" && playwright install chromium
 Save X session:       x-reader login twitter
 """
 
+import os
 import re
 import requests
+from html import unescape
+from pathlib import Path
 from loguru import logger
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+from urllib.parse import urlparse, urlunparse
 
 from x_reader.fetchers.jina import fetch_via_jina
 
 
 FXTWITTER_API = "https://api.fxtwitter.com"
 OEMBED_URL = "https://publish.twitter.com/oembed"
+JINA_BASE = "https://r.jina.ai"
+
+
+def _normalize_x_url(url: str) -> str:
+    """Normalize X/Twitter URLs and drop tracking query strings."""
+    url = url.strip()
+    if not url.startswith(("http://", "https://")):
+        url = f"https://{url}"
+    parsed = urlparse(url)
+    netloc = parsed.netloc.lower().replace("www.", "")
+    if netloc in ("twitter.com", "mobile.twitter.com"):
+        netloc = "x.com"
+    return urlunparse((parsed.scheme or "https", netloc, parsed.path, "", "", ""))
+
+
+def _extract_status_id(url: str) -> Optional[str]:
+    """Extract tweet/article id from common X URL shapes."""
+    patterns = (
+        r'x\.com/[^/]+/status/(\d+)',
+        r'x\.com/i/web/status/(\d+)',
+        r'x\.com/i/article/(\d+)',
+        r'x\.com/[^/]+/article/(\d+)',
+    )
+    for pattern in patterns:
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    return None
 
 
 def _extract_author(url: str) -> str:
     """Extract @username from tweet URL."""
-    match = re.search(r'x\.com/(\w+)/status', url)
+    match = re.search(r'x\.com/([A-Za-z0-9_]+)/(?:status|article)', url)
     return f"@{match.group(1)}" if match else ""
 
 
 def _is_tweet_url(url: str) -> bool:
     """Check if this is a direct tweet/status URL (vs profile or other X page)."""
-    return bool(re.search(r'x\.com/\w+/status/\d+', url))
+    return bool(
+        re.search(r'x\.com/[A-Za-z0-9_]+/status/\d+', url)
+        or re.search(r'x\.com/i/web/status/\d+', url)
+    )
+
+
+def _is_article_url(url: str) -> bool:
+    """Check if this is an X Article URL or status URL known to carry an article."""
+    return bool(
+        re.search(r'x\.com/i/article/\d+', url)
+        or re.search(r'x\.com/[A-Za-z0-9_]+/article/\d+', url)
+    )
+
+
+def _article_url_from_status(url: str) -> Optional[str]:
+    """Build the /i/article URL that X uses for long-form articles."""
+    status_id = _extract_status_id(url)
+    if not status_id:
+        return None
+    return f"https://x.com/i/article/{status_id}"
+
+
+def _strip_tweet_html(html: str) -> str:
+    """Extract readable text from X oEmbed HTML without the attribution footer."""
+    match = re.search(r'<p[^>]*>(.*?)</p>', html, flags=re.IGNORECASE | re.DOTALL)
+    fragment = match.group(1) if match else html
+    fragment = re.sub(r'<br\s*/?>', '\n', fragment, flags=re.IGNORECASE)
+    text = re.sub(r'<[^>]+>', '', fragment)
+    text = unescape(text)
+    text = re.sub(r'[ \t]+\n', '\n', text)
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    return text.strip()
+
+
+def _is_thin_oembed_text(text: str) -> bool:
+    """Detect oEmbed payloads that are likely cards, articles, or truncated text."""
+    normalized = text.strip()
+    if len(normalized) <= 20:
+        return True
+    if re.fullmatch(r'https://t\.co/\w+', normalized):
+        return True
+    if normalized.count("https://t.co/") >= 1 and len(normalized) < 80:
+        return True
+    if normalized.endswith("…") or normalized.endswith("..."):
+        return True
+    return False
+
+
+def _session_cookie_header(platform: str = "twitter") -> Optional[str]:
+    """Return minimal cookies from a saved Playwright session for authenticated fetches."""
+    if os.getenv("X_READER_ALLOW_EXTERNAL_SESSION_COOKIES") != "1":
+        return None
+
+    try:
+        from x_reader.fetchers.browser import get_session_path
+        import json
+
+        session_path = Path(get_session_path(platform))
+        if not session_path.exists():
+            return None
+        state = json.loads(session_path.read_text())
+        cookies = state.get("cookies", [])
+        wanted = {"auth_token", "ct0", "twid"}
+        values = []
+        for cookie in cookies:
+            name = cookie.get("name")
+            value = cookie.get("value")
+            domain = cookie.get("domain", "")
+            if name in wanted and value and ("x.com" in domain or "twitter.com" in domain):
+                values.append(f"{name}={value}")
+        return "; ".join(values) if values else None
+    except Exception as exc:
+        logger.warning(f"[Twitter] Could not read saved X session cookies ({exc})")
+        return None
 
 
 def _fetch_via_fxtwitter(url: str) -> Dict[str, Any]:
@@ -39,7 +145,7 @@ def _fetch_via_fxtwitter(url: str) -> Dict[str, Any]:
     Fetch full tweet text via FxTwitter API.
     Free, no auth, returns complete text (no truncation).
     """
-    match = re.search(r'x\.com/(\w+)/status/(\d+)', url)
+    match = re.search(r'x\.com/([A-Za-z0-9_]+)/status/(\d+)', url)
     if not match:
         raise ValueError(f"Cannot parse tweet URL: {url}")
 
@@ -67,28 +173,63 @@ def _fetch_via_oembed(url: str) -> Dict[str, Any]:
     """
     Fetch tweet text via X's oEmbed API.
     Free, reliable, no auth needed. Works for public tweets.
-    Note: oEmbed requires twitter.com URLs (not x.com).
     """
-    # oEmbed API requires twitter.com format
-    oembed_query_url = url.replace("x.com", "twitter.com")
     resp = requests.get(
         OEMBED_URL,
-        params={"url": oembed_query_url, "omit_script": "true"},
+        params={"url": url, "omit_script": "true"},
         timeout=10,
     )
     resp.raise_for_status()
     data = resp.json()
 
-    # Strip HTML tags from the embedded HTML to get clean text
     html = data.get("html", "")
-    text = re.sub(r'<[^>]+>', ' ', html)
-    text = re.sub(r'\s+', ' ', text).strip()
+    text = _strip_tweet_html(html)
 
     return {
         "text": text,
         "author": data.get("author_name", ""),
         "author_url": data.get("author_url", ""),
         "title": text[:100] if text else "",
+    }
+
+
+def _fetch_article_via_jina(url: str) -> Dict[str, Any]:
+    """
+    Fetch X Article content via Jina Reader.
+
+    By default this does not send local X cookies to Jina. Users can opt in by
+    setting X_READER_ALLOW_EXTERNAL_SESSION_COOKIES=1 if they trust the service.
+    """
+    article_url = url if _is_article_url(url) else _article_url_from_status(url)
+    if not article_url:
+        raise ValueError(f"Cannot build X Article URL from: {url}")
+
+    headers = {
+        "Accept": "text/markdown",
+        "User-Agent": "x-reader/0.2",
+    }
+    cookie_header = _session_cookie_header("twitter")
+    if cookie_header:
+        logger.info("[Twitter] Forwarding saved X session cookies to Jina (explicit opt-in)")
+        headers["X-Set-Cookie"] = cookie_header
+
+    resp = requests.get(f"{JINA_BASE}/{article_url}", headers=headers, timeout=20)
+    resp.raise_for_status()
+    content = resp.text.strip()
+    content = re.sub(r'\n{3,}', '\n\n', content)
+    if not content or "This page requires JavaScript" in content:
+        raise ValueError("Jina returned empty or JS-only article content")
+
+    title = ""
+    title_match = re.search(r'^Title:\s*(.+)$', content, flags=re.MULTILINE)
+    if title_match:
+        title = title_match.group(1).strip()
+
+    return {
+        "text": content,
+        "author": _extract_author(url),
+        "url": article_url,
+        "title": title or content[:100],
     }
 
 
@@ -182,13 +323,32 @@ async def fetch_twitter(url: str) -> Dict[str, Any]:
     Returns:
         Dict with: text, author, url, title, platform
     """
-    url = url.replace("twitter.com", "x.com")
+    url = _normalize_x_url(url)
     author = _extract_author(url)
 
-    # Tier 1: FxTwitter API (full text, no truncation)
+    # Tier 1: oEmbed probe. This is fastest and does not require auth.
     if _is_tweet_url(url):
         try:
-            logger.info(f"[Twitter] Tier 1 — FxTwitter: {url}")
+            logger.info(f"[Twitter] Tier 1 — oEmbed probe: {url}")
+            data = _fetch_via_oembed(url)
+            text = (data.get("text") or "").strip()
+            if text and not _is_thin_oembed_text(text):
+                return {
+                    "text": text,
+                    "author": author or data.get("author", ""),
+                    "url": url,
+                    "title": data.get("title", ""),
+                    "platform": "twitter",
+                    "fetch_method": "oembed",
+                }
+            logger.warning("[Twitter] oEmbed returned thin or truncated content")
+        except Exception as e:
+            logger.warning(f"[Twitter] oEmbed failed ({e})")
+
+    # Tier 2: FxTwitter API (structured public tweet fallback).
+    if _is_tweet_url(url):
+        try:
+            logger.info(f"[Twitter] Tier 2 — FxTwitter: {url}")
             data = _fetch_via_fxtwitter(url)
             text = (data.get("text") or "").strip()
             if text:
@@ -198,37 +358,35 @@ async def fetch_twitter(url: str) -> Dict[str, Any]:
                     "url": url,
                     "title": data.get("title", ""),
                     "platform": "twitter",
+                    "fetch_method": "fxtwitter",
                 }
             logger.warning("[Twitter] FxTwitter returned empty text")
         except Exception as e:
             logger.warning(f"[Twitter] FxTwitter failed ({e})")
 
-    # Tier 2: oEmbed API (fast but truncates long tweets)
-    if _is_tweet_url(url):
+    # Tier 3: X Article via Jina + saved session cookies.
+    # For status URLs this is attempted only after short tweet methods fail.
+    if _is_article_url(url) or _is_tweet_url(url):
         try:
-            logger.info(f"[Twitter] Tier 2 — oEmbed: {url}")
-            data = _fetch_via_oembed(url)
+            logger.info(f"[Twitter] Tier 3 — X Article via Jina: {url}")
+            data = _fetch_article_via_jina(url)
             text = (data.get("text") or "").strip()
-            thin_oembed = (
-                len(text) <= 20
-                or text.lower().startswith("https://t.co/")
-                or ("&mdash;" in text and text.count("https://t.co/") >= 1)
-            )
-            if not thin_oembed:
+            if text and len(text) > 100:
                 return {
                     "text": text,
                     "author": author or data.get("author", ""),
-                    "url": url,
+                    "url": data.get("url", url),
                     "title": data.get("title", ""),
                     "platform": "twitter",
+                    "fetch_method": "x_article_jina",
                 }
-            logger.warning("[Twitter] oEmbed returned thin content")
+            logger.warning("[Twitter] X Article Jina returned short content")
         except Exception as e:
-            logger.warning(f"[Twitter] oEmbed failed ({e})")
+            logger.warning(f"[Twitter] X Article Jina failed ({e})")
 
-    # Tier 3: Jina Reader (handles profiles, threads, non-tweet pages)
+    # Tier 4: Jina Reader (handles profiles, threads, non-tweet pages)
     try:
-        logger.info(f"[Twitter] Tier 3 — Jina: {url}")
+        logger.info(f"[Twitter] Tier 4 — Jina: {url}")
         data = fetch_via_jina(url)
         content = data.get("content", "")
         title = data.get("title", "")
@@ -245,14 +403,15 @@ async def fetch_twitter(url: str) -> Dict[str, Any]:
                 "url": url,
                 "title": title,
                 "platform": "twitter",
+                "fetch_method": "jina",
             }
         logger.warning("[Twitter] Jina returned unusable content")
     except Exception as e:
         logger.warning(f"[Twitter] Jina failed ({e})")
 
-    # Tier 4: Playwright + session with X-specific extraction
+    # Tier 5: Playwright + session with X-specific extraction
     try:
-        logger.info(f"[Twitter] Tier 4 — Playwright: {url}")
+        logger.info(f"[Twitter] Tier 5 — Playwright: {url}")
         data = await _fetch_via_playwright(url)
         content = data.get("text", "")
         if content and len(content.strip()) > 20:
@@ -262,6 +421,7 @@ async def fetch_twitter(url: str) -> Dict[str, Any]:
                 "url": url,
                 "title": data.get("title", ""),
                 "platform": "twitter",
+                "fetch_method": "playwright",
             }
         logger.warning("[Twitter] Playwright returned empty content")
     except RuntimeError:
@@ -271,6 +431,6 @@ async def fetch_twitter(url: str) -> Dict[str, Any]:
 
     raise RuntimeError(
         f"❌ All Twitter fetch methods failed for: {url}\n"
-        f"   Try: x-reader login twitter (to save session for browser fallback)\n"
+        f"   Try: x-reader login twitter (to save session for Article/browser fallback)\n"
         f"   Then retry: x-reader {url}"
     )

--- a/x_reader/schema.py
+++ b/x_reader/schema.py
@@ -159,16 +159,21 @@ def from_bilibili(video: dict) -> UnifiedContent:
 
 
 def from_twitter(data: dict) -> UnifiedContent:
+    extra = {
+        "likes": data.get('likes', 0),
+        "retweets": data.get('retweets', 0),
+        "fetch_method": data.get('fetch_method', ''),
+    }
+    if data.get('author_url'):
+        extra["author_url"] = data.get('author_url')
+
     return UnifiedContent(
         source_type=SourceType.TWITTER,
         source_name=data.get('author', ''),
         title=data.get('text', '')[:100],
         content=data.get('text', ''),
         url=data.get('url', ''),
-        extra={
-            "likes": data.get('likes', 0),
-            "retweets": data.get('retweets', 0),
-        },
+        extra=extra,
     )
 
 


### PR DESCRIPTION
## What changed
- Add a layered X/Twitter reader fallback path: oEmbed, FxTwitter, X Article/Jina, generic Jina, Playwright.
- Preserve fetch provenance in Twitter metadata.
- Gate external cookie/session forwarding behind explicit opt-in and log when it is used.
- Add tests for fallback behavior and cookie boundaries.
- Tighten public release docs and add README.zh.md compatibility entry.

## Verification
- python3 -m unittest discover -s tests
- python3 -m compileall x_reader tests
- git diff --check HEAD~2 HEAD
- opensource-preflight.sh on git archive exported to /tmp/x-reader-preflight-20260531

## Privacy
- Default path keeps saved X session/cookies local.
- External session forwarding requires X_READER_ALLOW_EXTERNAL_SESSION_COOKIES=1.