### PR TITLE
docs: fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ User sends URL
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=runesleo/x-reader&type=Date)](https://star-history.com/#runesleo/x-reader&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=runesleo/x-reader&type=Date)](https://star-history.dera.page/#runesleo/x-reader&Date)
 
 ## Author
 


### PR DESCRIPTION
The Star History chart in the README is no longer rendering because the upstream service was limited by GitHub API restrictions. This PR points it at the maintained mirror at star-history.dera.page so the chart works again.